### PR TITLE
Drupal 8

### DIFF
--- a/iform.module
+++ b/iform.module
@@ -814,7 +814,7 @@ function iform_view($node, $view_mode) {
     }
     // Now retrieve the form content
     try {
-      $r .= call_user_func(array('iform_' . $node->iform, 'get_form'), $args, $node, $response);
+      $r .= call_user_func(array('iform_' . $node->iform, 'get_form'), $args, $node->nid, $response);
     } catch (Exception $e) {
       watchdog('debug', 'Error occurred loading form');
       watchdog('debug', $e->getMessage());


### PR DESCRIPTION
Merge changes to support Drupal 8 into develop. Mainly a change to calls to get_form so that $nid is passed rather than the $node, since $node is Drupal version dependent.
