### PR TITLE
Work to allow basemap override and dynamic switching

### DIFF
--- a/modules/iform_user_ui_options/iform_user_ui_options.module
+++ b/modules/iform_user_ui_options/iform_user_ui_options.module
@@ -24,17 +24,19 @@ function iform_user_ui_options_form_user_profile_form_alter(&$form) {
       if (!isset($optionset['title']) || !isset($optionset['choices'])) {
         throw new exception('Incorrect structure for $file. Missing title or choices.');
       }
-      $radioOptions = array('default' => 'Use the default settings for each page');
-      foreach ($optionset['choices'] as $choiceName => $choiceSettings) {
-        $radioOptions[$choiceName] = t($choiceSettings['title']) .
-            '<br/><div class="description">' . t($choiceSettings['description']) . '</div>';
-      }
-      $form['Preferences']['ui_options']["iform_user_ui_$name"] = array(
-        '#type' => 'radios',
-        '#title' => check_plain(t($optionset['title'])),
-        '#options' => $radioOptions,
-        '#default_value' => !empty($currentOpts[$name]) ? $currentOpts[$name] : 'default'
-      );
+      if (count($optionset['choices']) > 1) {
+        $radioOptions = array('default' => 'Use the default settings for each page');
+        foreach ($optionset['choices'] as $choiceName => $choiceSettings) {
+          $radioOptions[$choiceName] = t($choiceSettings['title']) .
+              '<br/><div class="description">' . t($choiceSettings['description']) . '</div>';
+        }
+        $form['Preferences']['ui_options']["iform_user_ui_$name"] = array(
+          '#type' => 'radios',
+          '#title' => check_plain(t($optionset['title'])),
+          '#options' => $radioOptions,
+          '#default_value' => !empty($currentOpts[$name]) ? $currentOpts[$name] : 'default'
+        );
+      } 
     }
   }
   // Hide warehouse link and remembered field mappings unless admin.
@@ -129,6 +131,13 @@ function iform_user_ui_options_preprocess_iform(array &$params) {
           if (strpos($param, '|') === FALSE) {
             // An iform parameter override.
             $paramsToApply[$param] = $value;
+            if ($param == "preset_layers") {
+              //If preset_layers is set at this point, then it has been set in 
+              //a JSON config file to override the layers available on all forms.
+              //Here we set a JS variable so that the map selection div can be removed
+              //from forms (where appropriate)
+              drupal_add_js(array('iform_user_ui_options' => array('basemap_layers_override' => TRUE)), array('type' => 'setting'));
+            }
           }
           else {
             // Aform structure control property override. Store it for later, will be used by dynamic.php in


### PR DESCRIPTION
Also depends on new work in media and client_helper modules.

I created a configuration file C:\xampp\htdocs\drupal7\sites\default\files\iform_user_ui_options\basemap.json - following the existing protocol - to set the input form variable preset_layers. This only has one option - the default option - which dictates the layers to set.

It looks like this:

```
{
  "basemap_override": {
    "title": "Basemap layers override",
    "description": "Presents a single option so it won't be presented to user and just applied across pages",
    "choices": {
      "default": {
        "title": "",
        "description": "",
        "params": {
          "preset_layers": ["dynamic1", "dynamic2", "osm"]
        }
      }
    }
  }
}
```

I tweaked iform_user_ui_options.module so that if a single option is detected in one of these configuration files, the option is not presented to the user on their profile edit page as it would be for multiple options.

I also modified this module so that when it detects that preset_layers is set through a JSON config file, it sets a Drupal JS variable - basemap_layers_override - which is used by JS to hide basemap selection.
