### PR TITLE
Add login message to warn if media licence not set

### DIFF
--- a/modules/iform_licences/iform_licences.module
+++ b/modules/iform_licences/iform_licences.module
@@ -24,6 +24,7 @@ function iform_licences_variable_info($options) {
 }
 
 function iform_licences_form_alter(&$form, &$form_state, $form_id) {
+  iform_load_helpers(array('data_entry_helper'));
   if (($form_id === 'user_profile_form' || $form_id === 'user_register_form')) {
     $conn = iform_get_connection_details(NULL);
     $readAuth = data_entry_helper::get_read_auth($conn['website_id'], $conn['password']);
@@ -143,4 +144,27 @@ function iform_licences_form_submit($form, &$form_state) {
     }
   }
 
+}
+
+function iform_licences_user_login (&$edit, $account) {
+
+  if (user_is_logged_in()) {
+
+    iform_load_helpers(array('data_entry_helper'));
+    //require_once iform_client_helpers_path() . 'data_entry_helper.php';
+    $readAuth=data_entry_helper::get_read_auth(variable_get('indicia_website_id',''), variable_get('indicia_password',''));
+    $indiciaUserId = $account->field_indicia_user_id[LANGUAGE_NONE]['0']['value'];
+    $current = data_entry_helper::get_population_data(array(
+      'table' => 'users_website',
+      'extraParams' => $readAuth + array(
+          'user_id' => $indiciaUserId,
+          'columns' => 'media_licence_id'
+        ),
+      'caching' => FALSE,
+    ));
+    $currentMediaLicenceId = $current[0]['media_licence_id'];
+    if (!isset($currentMediaLicenceId)) {
+      drupal_set_message(t('You <b>HAVE NOT</b> specified a media license'));
+    }
+  }
 }

--- a/modules/iform_licences/iform_licences.module
+++ b/modules/iform_licences/iform_licences.module
@@ -151,7 +151,6 @@ function iform_licences_user_login (&$edit, $account) {
   if (user_is_logged_in()) {
 
     iform_load_helpers(array('data_entry_helper'));
-    //require_once iform_client_helpers_path() . 'data_entry_helper.php';
     $readAuth=data_entry_helper::get_read_auth(variable_get('indicia_website_id',''), variable_get('indicia_password',''));
     $indiciaUserId = $account->field_indicia_user_id[LANGUAGE_NONE]['0']['value'];
     $current = data_entry_helper::get_population_data(array(
@@ -164,7 +163,7 @@ function iform_licences_user_login (&$edit, $account) {
     ));
     $currentMediaLicenceId = $current[0]['media_licence_id'];
     if (!isset($currentMediaLicenceId)) {
-      drupal_set_message(t('You <b>HAVE NOT</b> specified a media license'));
+      drupal_set_message(t('You have not yet specified a media licence yet. This limits to usefulness of your images. To set a licence, edit your <a href="user">profile page</a>, and select an option.'));
     }
   }
 }


### PR DESCRIPTION
@johnvanbreda - can you have a look at this? It's not the finished article yet (but it works). I have a couple of questions...

Even before I did the coding, I had a problem on my local setup: once I'd enabled the iform_licenses module, my site fell over whenever I tried to register a new user. The PHP error complained that the 'data_entry_helper' couldn't be found (this was line 29 - now 30). I fixed it by inserting this line before the call: `iform_load_helpers(array('data_entry_helper'));`

But this 'bug' is not evident on the irecord_dev site where the iform_licenses module is enabled. On that site the registration form for a new user is shown without a problem. Consequently I wonder if there could be some other problem with my setup that leads to data_entry_helper not being in scope when called. 

I've used the same `iform_load_helpers(array('data_entry_helper'));` call in the new `iform_licences_user_login` hook function.

The message that the user sees is just a place holder at the moment - we can make it stronger. I wonder if it's strong enough? Do we need to make this message a bit more 'in your face'?