### PR TITLE
Iss 638 4

### DIFF
--- a/modules/iform_licences/iform_licences.module
+++ b/modules/iform_licences/iform_licences.module
@@ -163,8 +163,8 @@ function iform_licences_user_login (&$edit, $account) {
     ));
     $currentMediaLicenceId = $current[0]['media_licence_id'];
     if (!isset($currentMediaLicenceId)) {
-      $link = url('user/' . $user->uid . '/edit');
-      drupal_set_message(t('You have not yet specified a media licence. This limits the usefulness of your images. <a href="@link#licenceopts">To set a licence, edit your profile page, and select an option.</a>', ['@link' => $link]));
+      $link = url('user/' . $user->uid . '/edit', ['fragment' => 'licenceopts']);
+      drupal_set_message(t('You have not yet specified a media licence. This limits the usefulness of your images. <a href="@link">To set a licence, edit your profile page, and select an option.</a>', ['@link' => $link]));
     }
   }
 }

--- a/modules/iform_licences/iform_licences.module
+++ b/modules/iform_licences/iform_licences.module
@@ -163,7 +163,7 @@ function iform_licences_user_login (&$edit, $account) {
     ));
     $currentMediaLicenceId = $current[0]['media_licence_id'];
     if (!isset($currentMediaLicenceId)) {
-      drupal_set_message(t('You have not yet specified a media licence. This limits the usefulness of your images. <a href="user/@userid/edit#licenceopts">To set a licence, edit your profile page, and select an option.</a>', ['@userid' => $user->uid]));
+      drupal_set_message(t('You have not yet specified a media licence. This limits the usefulness of your images. <a href="/user/@userid/edit#licenceopts">To set a licence, edit your profile page, and select an option.</a>', ['@userid' => $user->uid]));
     }
   }
 }

--- a/modules/iform_licences/iform_licences.module
+++ b/modules/iform_licences/iform_licences.module
@@ -163,7 +163,8 @@ function iform_licences_user_login (&$edit, $account) {
     ));
     $currentMediaLicenceId = $current[0]['media_licence_id'];
     if (!isset($currentMediaLicenceId)) {
-      drupal_set_message(t('You have not yet specified a media licence. This limits the usefulness of your images. <a href="/user/@userid/edit#licenceopts">To set a licence, edit your profile page, and select an option.</a>', ['@userid' => $user->uid]));
+      $link = url('user/' . $user->uid . '/edit');
+      drupal_set_message(t('You have not yet specified a media licence. This limits the usefulness of your images. <a href="@link#licenceopts">To set a licence, edit your profile page, and select an option.</a>', ['@link' => $link]));
     }
   }
 }


### PR DESCRIPTION
Unders some circumstances (possibly connected to masquerading) link to user's profile edit page could be incorrectly generated because I was using a relative path user/....., assuming link would always be relative to root. 

(See for example: https://github.com/BiologicalRecordsCentre/iRecord/issues/638#issuecomment-538397548)

Have corrected by explicitly generating the URL using the url function.