### PR TITLE
Update to iform_user_ui_options to allow override of georeferencer

### DIFF
--- a/modules/iform_user_ui_options/iform_user_ui_options.module
+++ b/modules/iform_user_ui_options/iform_user_ui_options.module
@@ -141,6 +141,15 @@ indiciaData.basemapLayersOverride = true;
 
 JS;
             }
+            if ($param == "georefDriver") {
+              // If georefDriver is set at this point, then it has been set in
+              // a JSON config file to override the georeferencing options available on 
+              // iForms. Set a JS variable so that the georeferencer selector can
+              // be disabled.
+              data_entry_helper::$javascript .= <<<JS
+indiciaData.georeferencerOverride = true;
+JS;
+            }
           }
           else {
             // A form structure control property override. Store it for later,


### PR DESCRIPTION
Issue https://github.com/BiologicalRecordsCentre/iRecord/issues/711 highlighted vulnerability of Indicia iForms to loss of georeferencing service. In this case the Nominatim service was unavailable for a short time. In the case of the loss of a georeferencing service, iRecord forms could individually be switched to another provider, e.g. in this case Google, but it would be better to have the option to globally override the selection of georeferencer on a per website basis rather than have to update all affected forms and then change them back again when service restored. This pull request - together with another on client_helpers, enables us to do that.