### PR TITLE
Changes to make a couple of user profile fields required on reg only

### DIFF
--- a/iform.module
+++ b/iform.module
@@ -1964,3 +1964,17 @@ function iform_metatag_metatags_view_alter(&$output, $instance, $options) {
 
   }
 }
+
+/**
+ * Implements hook_form_user_register_form_alter.
+ * Authentication for access to create, view and delete indicia form pages.
+ * @param $form
+ * @param $form_state
+ */
+function iform_form_user_register_form_alter(&$form, &$form_state) {
+  // If the Drupal field 'field_o13' exists on the user registration
+  // form, make it required.
+  if (array_key_exists('field_o13', $form)){
+    $form['field_u16'][LANGUAGE_NONE]['#required'] = TRUE;
+  }
+}

--- a/modules/iform_licences/iform_licences.module
+++ b/modules/iform_licences/iform_licences.module
@@ -92,7 +92,7 @@ function iform_licences_form_alter(&$form, &$form_state, $form_id) {
           '#title' => t('<span id="licenceopts">Licence for your @label</span>', ['@label' => $label]),
           '#options' => $options,
           '#description' => $description,
-          '#required' => TRUE,
+          '#required' => $form_id === 'user_register_form' ? TRUE: FALSE,
           '#default_value' => $thisLicenceId,
         );
       }


### PR DESCRIPTION
@johnvanbreda - this potentially addresses both the u13 iRecord flag problem and the licenses module problem from https://github.com/BiologicalRecordsCentre/iRecord/issues/907. But as noted on that issue, I'm not sure it is appropriate to deal with iRecord specific problem here? Also this code does not limit to iRecord website but if you are happy for me to proceed with this I can check the website ID to make specific to iRecord.